### PR TITLE
Use nodejs package from chris-lea/node.js PPA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM ubuntu:14.04
 
 MAINTAINER Berenice Venegas <bvcotero@gmail.com>
 
-RUN apt-get update
- 
-RUN apt-get install -y nodejs npm nodejs-legacy git
+RUN apt-get update -y
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository -y ppa:chris-lea/node.js
+RUN apt-get update -y
+RUN apt-get install -y nodejs
 
 RUN mkdir /app/
 


### PR DESCRIPTION
This uses the `nodejs` package from `ppa:chris-lea/node.js` instead of the legacy packages to avoid some potential issues with that older NPM version.
