### PR TITLE
rearrange README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,73 @@
 # Node-Jawn-Docker
 
-A Node.Js docker container with the purpose to be used by contributars to the Jawn project (https://github.com/CfABrigadePhiladelphia/jawn), in order to maintain a reproducible and consistent environment to test and run their code.
+A Node.Js docker container with the purpose to be used by contributors to the Jawn project (https://github.com/CfABrigadePhiladelphia/jawn), in order to maintain a reproducible and consistent environment to test and run their code.
 
 ## The container
 
 The container uses Ubuntu, and installs nodejs v4.x. The working directory is /app.
 In addition, this container comes with an rspec test to check the container builds properly and as expected (see below).
 
-## Usage
+## Getting Docker (Required)
 
 **Before you start**, you need to have docker installed on your machine. Follow the instructions for your OS on the [Docker Install page](https://docs.docker.com/engine/installation/)
 
-First clone the Node-Jawn-Docker git repository and cd into it. 
+## Getting the Image
+
+If you don't want to build this image yourself, you can use the [copy from dockerhub](https://hub.docker.com/r/jawn/node-jawn/) by running
+
+```
+docker pull jawn/node-jawn
+```
+
+If you want to build the image yourself from our Dockerfile, follow the [the build instructions below](#build-the-image).
+
+## Using the Image
+
+Whether you've installed the jawn/node-jawn image from dockerhub or built the image from the Dockerfile using [the instructions below](#build-the-image), these commands show you how to use the image to do things like test the jawn code or work in a bash terminal.
+
+The commands use docker's `-v` flag to tell the docker container where to find your source code. For example, if your code is at `/path/to/jawn`, you can make that code visible to the container using `-v "/path/to/jawn:/app"`.  If you change those files in /path/to/jawn the changes will be visible to the container. Likewise if the container changes those files (for example installing modules into node_modules), those changes will be visible to you on your filesystem.
+
+### First run `npm install`:
+
+**You must do this before trying to run `npm test`**
+
+This will tell npm to install your application's Node dependencies. It will read `/path/to/jawn/package.json` and install all of the dependencies listed in that file.  The dependencies get installed to `/path/to/jawn/node_modules`
+
+```
+docker run --rm \
+       -v "/path/to/jawn:/app" \
+       jawn/node-jawn \
+       npm install
+```
+
+### Run `npm test`:
+Run jawn's test suite using `npm test`
+
+```
+docker run --rm \
+       -v "/path/to/jawn:/app" \
+       jawn/node-jawn \
+       npm test
+```
+
+### Run a bash terminal:
+
+To work in a bash terminal within the container, include  the `-it` flags and tell docker to run `bash`
+
+```
+docker run --rm -it \
+       -v "/path/to/jawn:/app" \
+       jawn/node-jawn \
+       bash
+```
+
+## Building the Image
+_If you don't want to build the image yourself, you can use the copy from dockerhub. See [Getting the Image](#getting-the-image)_
+
+
+### Clone the Repo
+
+First clone the Node-Jawn-Docker git repository and cd into it.
 
 ```
 git clone git@github.com:clamorisse/Node-Jawn-Docker.git
@@ -28,44 +84,8 @@ docker build -t jawn/node-jawn .
 
 _Note:_ This example creates an image called `node-jawn` from the user `jawn`, but you can choose any name for the image you're building and for the application. `docker build -t user/your-image-name .`
 
-### Run the Image
+# Video: Building the Image and Running It
 
-Once the container's image has been built, you can run it. The different commands below to run it will map your application's directories into the container and anything you create or change will be automatically updated into your local computer.
-
-###First install npm:
-
-```
-docker run --rm \
-       -v "/path/to/jawn/index.js:/app/index.js" \
-       -v "/path/to/jawn/lib/:/app/lib/" \
-       -v "/path/to/jawn/test/:/app/test/" \
-       -v "/path/to/jawn/node_modules/:/app/node_modules/" \
-       jawn/node-jawn \
-       npm install
-```
-
-###Run your application:
-
-```
-docker run --rm \
-       -v "/path/to/jawn/index.js:/app/index.js" \
-       -v "/path/to/jawn/lib/:/app/lib/" \
-       -v "/path/to/jawn/test/:/app/test/" \
-       -v "/path/to/jawn/node_modules/:/app/node_modules/" \
-       jawn/node-jawn \
-       npm test
-```
-To work in the nodejs bash, mapping jawn files and directories:
-
-```
-docker run --rm -it \
-       -v "/path/to/jawn/index.js:/app/index.js" \
-       -v "/path/to/jawn/lib/:/app/lib/" \
-       -v "/path/to/jawn/test/:/app/test/" \
-       -v "/path/to/jawn/node_modules/:/app/node_modules/" \
-       jawn/node-jawn \
-       bash
-```
 [![asciicast](https://asciinema.org/a/32qm7ro3yw1ss0qvccgv7oafl.png)](https://asciinema.org/a/32qm7ro3yw1ss0qvccgv7oafl)
 
 # To test Dockerfile with rspec


### PR DESCRIPTION
Rearranges the README to emphasize the instructions for using the image.

Also simplifies the usage of the `-v` flag. This change assumes that CfAPhiladelphiaBrigade/jawn#39 has been applied to jawn (fixes the bug in jawn that forced us to use the more complicated `-v` flags)
